### PR TITLE
build(*): make android sources optional

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -10,8 +10,6 @@
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
-            <option value="$PROJECT_DIR$/../Leanplum-Android-SDK/AndroidSDK" />
-            <option value="$PROJECT_DIR$/../Leanplum-Android-UIEditor/AndroidSDKUIEditor" />
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 def COMPILE_SDK_VERSION = 27
 def BUILD_TOOLS_VERSION = '27.0.2'
 def SUPPORT_LIBRARY_VERSION = '27.0.2'
-def LP_VERSION = System.getenv('LP_VERSION') ?: '3.0.2-rc.1';
+def LP_VERSION = System.getenv('LP_VERSION') ?: '4.0.0'
 
 configurations.all {
     resolutionStrategy {
@@ -42,10 +42,10 @@ android {
     }
     productFlavors {
         packaged {
-            return void;
+            return void
         }
         sources {
-            return void;
+            return void
         }
     }
     buildTypes {
@@ -64,7 +64,6 @@ android {
     }
 }
 
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
@@ -78,19 +77,22 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
 
-    //App build types
-    packagedCompile 'com.leanplum:Leanplum:' + LP_VERSION
-    packagedCompile 'com.leanplum:UIEditor:' + LP_VERSION
-    sourcesDebugCompile project(':AndroidSDK')
-    sourcesReleaseCompile project( ':AndroidSDK')
+    // App build types
+    packagedCompile 'com.leanplum:leanplum-gcm:' + LP_VERSION
+    packagedCompile 'com.leanplum:leanplum-location:' + LP_VERSION
+    packagedCompile 'com.leanplum:leanplum-uieditor:' + LP_VERSION
+    // Uncomment the following lines if you'd like to compile the source code.
+    // sourcesDebugCompile project(':AndroidSDK')
+    // sourcesReleaseCompile project(':AndroidSDK')
 
     // Leanplum UI Editor SDK
     //noinspection GradleDynamicVersion
-    packagedDebugCompile 'com.leanplum:UIEditor:2.+'
+    packagedDebugCompile 'com.leanplum:leanplum-uieditor:' + LP_VERSION
     //noinspection GradleDynamicVersion
-    packagedReleaseCompile 'com.leanplum:UIEditor:2.+'
-    sourcesDebugCompile project(':AndroidSDKUIEditor')
-    sourcesReleaseCompile project(':AndroidSDKUIEditor')
+    packagedReleaseCompile 'com.leanplum:leanplum-uieditor:' + LP_VERSION
+    // Uncomment the following lines if you'd like to compile the source code.
+    // sourcesDebugCompile project(':AndroidSDKUIEditor')
+    // sourcesReleaseCompile project(':AndroidSDKUIEditor')
 
-    compile 'com.google.android.gms:play-services-gcm:11.6.2'
+    compile 'com.google.android.gms:play-services-gcm:11.8.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,29 @@
 include ':app'
-include ':AndroidSDK'
-project(':AndroidSDK').projectDir = new File('../Leanplum-Android-SDK/AndroidSDK')
-include ':AndroidSDKUIEditor'
-project(':AndroidSDKUIEditor').projectDir = new File('..//Leanplum-Android-UIEditor/AndroidSDKUIEditor')
+
+// Uncomment the following lines if you'd like to compile the source code.
+//include ':AndroidSDK'
+//project(':AndroidSDK').projectDir = new File('../Leanplum-Android-SDK/AndroidSDK')
+//
+//include ':AndroidSDKTests'
+//project(':AndroidSDKTests').projectDir = new File('../Leanplum-Android-SDK/AndroidSDKTests')
+//
+//include ':AndroidSDKCore'
+//project(':AndroidSDKCore').projectDir = new File('../Leanplum-Android-SDK/AndroidSDKCore')
+//
+//include ':AndroidSDKPush'
+//project(':AndroidSDKPush').projectDir = new File('../Leanplum-Android-SDK/AndroidSDKPush')
+//
+//include ':AndroidSDKGcm'
+//project(':AndroidSDKGcm').projectDir = new File('../Leanplum-Android-SDK/AndroidSDKGcm')
+//
+//include ':AndroidSDKFcm'
+//project(':AndroidSDKFcm').projectDir = new File('../Leanplum-Android-SDK/AndroidSDKFcm')
+//
+//include ':AndroidSDKLocation'
+//project(':AndroidSDKLocation').projectDir = new File('../Leanplum-Android-SDK/AndroidSDKLocation')
+//
+//include ':AndroidSDKUIEditor'
+//project(':AndroidSDKUIEditor').projectDir = new File('../Leanplum-Android-UIEditor/AndroidSDKUIEditor')
+//
+//include ':AndroidSDKUIEditorTests'
+//project(':AndroidSDKUIEditorTests').projectDir = new File('../Leanplum-Android-UIEditor/AndroidSDKUIEditorTests')


### PR DESCRIPTION
This PR makes the Leanplum SDK sources optional, by default It will use stable SDK.